### PR TITLE
Added Soil Moisture sensor and changes to DHT sensor code.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "idf.flashType": "UART",
     "idf.port": "/dev/tty.usbserial-0001",
     "files.associations": {
-        "app_priv.h": "c"
+        "app_priv.h": "c",
+        "adc_oneshot.h": "c"
     }
 }

--- a/components/csms_v2/CMakeLists.txt
+++ b/components/csms_v2/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "csms_v2.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES driver esp_adc)

--- a/components/csms_v2/csms_v2.c
+++ b/components/csms_v2/csms_v2.c
@@ -20,6 +20,11 @@ const static char *TAG = "CSMC_V2";
 static bool example_adc_calibration_init(adc_unit_t unit, adc_channel_t channel, adc_atten_t atten, adc_cali_handle_t *out_handle);
 static void example_adc_calibration_deinit(adc_cali_handle_t handle);
 
+// Function to retrive the average soil moisture data stored in the global variable adc_data
+const int* get_average_soil_moisture_data() {
+    return adc_data; // Return the array's pointer
+}
+
 // Function to select the multiplexer channel
 void select_mux_channel(uint8_t channel) {
     gpio_set_level(MUX_S0_PIN, channel & 0x01);

--- a/components/csms_v2/csms_v2.c
+++ b/components/csms_v2/csms_v2.c
@@ -1,0 +1,152 @@
+#include <stdio.h>
+#include "csms_v2.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "esp_adc/adc_oneshot.h"
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+
+static int adc_raw[NUM_CHANNELS];
+static int adc_data[NUM_CHANNELS];
+static int voltage[NUM_CHANNELS];
+
+const static char *TAG = "CSMC_V2";
+
+static bool example_adc_calibration_init(adc_unit_t unit, adc_channel_t channel, adc_atten_t atten, adc_cali_handle_t *out_handle);
+static void example_adc_calibration_deinit(adc_cali_handle_t handle);
+
+// Function to select the multiplexer channel
+void select_mux_channel(uint8_t channel) {
+    gpio_set_level(MUX_S0_PIN, channel & 0x01);
+    gpio_set_level(MUX_S1_PIN, (channel >> 1) & 0x01);
+    gpio_set_level(MUX_S2_PIN, (channel >> 2) & 0x01);
+    gpio_set_level(MUX_S3_PIN, (channel >> 3) & 0x01);
+}
+
+// Function to set the average soil moisture data
+void set_average_soil_moisture_data(void *pvParameters)
+{
+    // Initialize GPIO pins for multiplexer control
+    gpio_config_t io_conf = {
+        .pin_bit_mask = (1ULL << MUX_S0_PIN) | (1ULL << MUX_S1_PIN) | (1ULL << MUX_S2_PIN) | (1ULL << MUX_S3_PIN),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&io_conf);
+
+    //-------------ADC1 Init---------------//
+    adc_oneshot_unit_handle_t adc1_handle;
+    adc_oneshot_unit_init_cfg_t init_config1 = {
+        .unit_id = ADC_UNIT_1,
+    };
+    ESP_ERROR_CHECK(adc_oneshot_new_unit(&init_config1, &adc1_handle));
+
+    //-------------ADC1 Config---------------//
+    adc_oneshot_chan_cfg_t config = {
+        .bitwidth = ADC_BITWIDTH_DEFAULT,
+        .atten = EXAMPLE_ADC_ATTEN,
+    };
+    ESP_ERROR_CHECK(adc_oneshot_config_channel(adc1_handle, EXAMPLE_ADC1_CHAN0, &config));
+
+    //-------------ADC1 Calibration Init---------------//
+    adc_cali_handle_t adc1_cali_chan0_handle = NULL;
+    bool do_calibration1_chan0 = example_adc_calibration_init(ADC_UNIT_1, EXAMPLE_ADC1_CHAN0, EXAMPLE_ADC_ATTEN, &adc1_cali_chan0_handle);
+
+    while (1) {
+        for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
+            int adc_sum = 0;
+            int voltage_sum = 0;
+            for (int i = 0; i < SAMPLE_COUNT; i++) {
+                select_mux_channel(channel);
+                vTaskDelay(50 / portTICK_PERIOD_MS); // wait for the mux to settle
+                ESP_ERROR_CHECK(adc_oneshot_read(adc1_handle, EXAMPLE_ADC1_CHAN0, &adc_raw[channel]));
+                adc_sum += adc_raw[channel];
+                if (do_calibration1_chan0) {
+                    ESP_ERROR_CHECK(adc_cali_raw_to_voltage(adc1_cali_chan0_handle, adc_raw[channel], &voltage[channel]));
+                    voltage_sum += voltage[channel];
+                }
+                vTaskDelay(100 / portTICK_PERIOD_MS); // interval between readings
+            }
+            adc_data[channel] = adc_sum / SAMPLE_COUNT;
+            if (do_calibration1_chan0) {
+                voltage[channel] = voltage_sum / SAMPLE_COUNT;
+            }
+            //ESP_LOGI(TAG, "Updated Channel [%d]: %d mV ", channel, voltage[channel]);
+            vTaskDelay(100 / portTICK_PERIOD_MS); // interval between readings
+        }
+
+        vTaskDelay(1000 / portTICK_PERIOD_MS); // interval between cycles
+    }
+
+    //Tear Down
+    ESP_ERROR_CHECK(adc_oneshot_del_unit(adc1_handle));
+    if (do_calibration1_chan0) {
+        example_adc_calibration_deinit(adc1_cali_chan0_handle);
+    }
+    vTaskDelete(NULL);
+}
+
+/*---------------------------------------------------------------
+    ADC Calibration
+---------------------------------------------------------------*/
+static bool example_adc_calibration_init(adc_unit_t unit, adc_channel_t channel, adc_atten_t atten, adc_cali_handle_t *out_handle)
+{
+    adc_cali_handle_t handle = NULL;
+    esp_err_t ret = ESP_FAIL;
+    bool calibrated = false;
+
+    // Only line fitting calibration scheme is supported for ESP32.
+    if (!calibrated) {
+    ESP_LOGI(TAG, "calibration scheme version is %s", "Line Fitting");
+    adc_cali_line_fitting_config_t cali_config = {
+        .unit_id = unit,
+        .atten = atten,
+        .bitwidth = ADC_BITWIDTH_DEFAULT,
+    };
+    ret = adc_cali_create_scheme_line_fitting(&cali_config, &handle);
+    if (ret == ESP_OK) {
+        calibrated = true;
+    }
+    }
+
+    *out_handle = handle;
+    if (ret == ESP_OK) {
+    ESP_LOGI(TAG, "Calibration Success");
+    } else if (ret == ESP_ERR_NOT_SUPPORTED || !calibrated) {
+    ESP_LOGW(TAG, "eFuse not burnt, skip software calibration");
+    } else {
+    ESP_LOGE(TAG, "Invalid arg or no memory");
+    }
+
+    return calibrated;
+}
+
+static void example_adc_calibration_deinit(adc_cali_handle_t handle)
+{
+    // Only line fitting calibration scheme is supported for ESP32.
+    ESP_LOGI(TAG, "deregister %s calibration scheme", "Line Fitting");
+    ESP_ERROR_CHECK(adc_cali_delete_scheme_line_fitting(handle));
+}
+
+void display_average_soil_moisture_data(void *pvParameters) {
+    while (true) {
+        char mean_values[256] = {0};
+        snprintf(mean_values, sizeof(mean_values), "Mean Values:");
+
+        for (int channel = 0; channel < NUM_CHANNELS; channel++) {
+            char buffer[16];
+            snprintf(buffer, sizeof(buffer), " %d:%d", channel, adc_data[channel]);
+            strncat(mean_values, buffer, sizeof(mean_values) - strlen(mean_values) - 1);
+        }
+
+        ESP_LOGI(TAG, "%s", mean_values);
+        vTaskDelay(pdMS_TO_TICKS(30000)); // Display every 30 seconds
+    }
+}

--- a/components/csms_v2/include/csms_v2.h
+++ b/components/csms_v2/include/csms_v2.h
@@ -21,6 +21,9 @@
 #define SAMPLE_COUNT    10             // Number of samples for smoothing
 #define NUM_CHANNELS    16             // Number of channels on the multiplexer
 #define OUTLIER_THRESHOLD 500          // Define the acceptable deviation threshold
+#define CSMSV2_REPORTING_PERIOD            60
 
 void set_average_soil_moisture_data(void *pvParameters);
 void display_average_soil_moisture_data(void *pvParameters);
+// Function to retrive the average soil moisture data stored in the global variable adc_data
+const int* get_average_soil_moisture_data();

--- a/components/csms_v2/include/csms_v2.h
+++ b/components/csms_v2/include/csms_v2.h
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "esp_adc/adc_oneshot.h"
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+
+// Define GPIO pins for multiplexer control
+#define MUX_S0_PIN  GPIO_NUM_12
+#define MUX_S1_PIN  GPIO_NUM_13
+#define MUX_S2_PIN  GPIO_NUM_14
+#define MUX_S3_PIN  GPIO_NUM_15
+
+/*---------------------------------------------------------------
+    ADC General Macros
+---------------------------------------------------------------*/
+//ADC1 Channels
+#define EXAMPLE_ADC1_CHAN0          ADC_CHANNEL_0
+#define EXAMPLE_ADC_ATTEN           ADC_ATTEN_DB_12
+
+#define SAMPLE_COUNT    10             // Number of samples for smoothing
+#define NUM_CHANNELS    16             // Number of channels on the multiplexer
+#define OUTLIER_THRESHOLD 500          // Define the acceptable deviation threshold
+
+void set_average_soil_moisture_data(void *pvParameters);
+void display_average_soil_moisture_data(void *pvParameters);

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,4 +1,10 @@
 dependencies:
+  csms_v2:
+    dependencies: []
+    source:
+      path: /Users/ishwar/MicroControllers/ESP-Rainmaker-Projects/planty/components/csms_v2
+      type: local
+    version: '*'
   dht21:
     dependencies:
     - git: https://github.com/UncleRus/esp-idf-lib.git
@@ -206,6 +212,7 @@ dependencies:
       type: local
     version: 1.1.0
 direct_dependencies:
+- csms_v2
 - dht21
 - espressif/cbor
 - espressif/dht
@@ -224,6 +231,6 @@ direct_dependencies:
 - espressif/network_provisioning
 - espressif/rmaker_common
 - idf
-manifest_hash: 907f411f53b935fcea0e4eb4882c908b6241341c1642972c667d669f2a45f027
+manifest_hash: 0856fc22c499577a4ee5362d8355f3e1c9a99554eccc08a4fa72cffb47acb5f6
 target: esp32
 version: 2.0.0

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS ./app_driver.c ./app_main.c ./app_dht21.c
+idf_component_register(SRCS ./app_driver.c ./app_main.c ./app_dht21.c ./app_csms_v2.c 
                        INCLUDE_DIRS ".")

--- a/main/app_csms_v2.c
+++ b/main/app_csms_v2.c
@@ -1,0 +1,48 @@
+#include "app_priv.h"
+#include "csms_v2.h"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/timers.h>
+#include <esp_rmaker_standard_types.h>
+#include <string.h>
+
+#include "esp_log.h"
+
+static const char *TAG = "CSMC_V2_SENSOR";
+static TimerHandle_t s_sensor_timer;
+
+/* soil moisture sensor */
+static void update_soil_moisture_sensor_data(TimerHandle_t handle)
+{
+    const int* adc_values = get_average_soil_moisture_data();
+    char mean_values[256] = {0};
+    snprintf(mean_values, sizeof(mean_values), "Soil Moisture Values:");
+
+    for (int channel = 0; channel < NUM_CHANNELS; channel++) {
+        char buffer[NUM_CHANNELS];
+        snprintf(buffer, sizeof(buffer), " %d:%d", channel, adc_values[channel]);
+        strncat(mean_values, buffer, sizeof(mean_values) - strlen(mean_values) - 1);
+    }
+
+    ESP_LOGI(TAG, "%s", mean_values);
+    
+    /*
+    esp_rmaker_param_update_and_report(
+                esp_rmaker_device_get_param_by_type(temp_sensor_device, ESP_RMAKER_PARAM_TEMPERATURE),
+                esp_rmaker_float(get_average_temperature()));
+
+    */  
+}
+
+
+esp_err_t soil_moisture_sensor_init(void)
+{
+    s_sensor_timer = xTimerCreate("update_soil_moisture_sensor_data", (CSMSV2_REPORTING_PERIOD * 1000) / portTICK_PERIOD_MS,
+                            pdTRUE, NULL, update_soil_moisture_sensor_data);
+    if (s_sensor_timer) {
+        xTimerStart(s_sensor_timer, 0);
+        return ESP_OK;
+    }
+    return ESP_FAIL;
+}
+/* soil moisture sensor - END */

--- a/main/app_dht21.c
+++ b/main/app_dht21.c
@@ -15,12 +15,13 @@ static void update_temperature_sensor_data(TimerHandle_t handle)
 {
     ESP_LOGI(TAG, "Updating Temp: %.1fC\n", get_average_temperature());
     esp_rmaker_param_update_and_report(
-                esp_rmaker_device_get_param_by_type(temp_sensor_device, ESP_RMAKER_PARAM_TEMPERATURE),
-                esp_rmaker_float(get_average_temperature()));
+            // _by_type returns the first parameter of the given type. If you have multiple parameters of the same type, you should use _by_name. 'temperature' is the name of the parameter, in case you want to use _by_name
+            esp_rmaker_device_get_param_by_type(temp_sensor_device, ESP_RMAKER_PARAM_TEMPERATURE), 
+            esp_rmaker_float(get_average_temperature()));
     ESP_LOGI(TAG, "Updating Humidity: %.1f%%\n", get_average_humidity());
     esp_rmaker_param_update_and_report(
-                esp_rmaker_device_get_param_by_name(temp_sensor_device, "Humidity"),    // 'Humidity' is the name of the parameter
-                esp_rmaker_float(get_average_humidity()));
+            esp_rmaker_device_get_param_by_name(temp_sensor_device, "Humidity"),    // 'Humidity' is the name of the parameter
+            esp_rmaker_float(get_average_humidity()));
 }
 
 esp_err_t temperature_sensor_init(void)

--- a/main/app_dht21.c
+++ b/main/app_dht21.c
@@ -9,7 +9,6 @@
 
 static const char *TAG = "DHT_SENSOR";
 static TimerHandle_t t_sensor_timer;
-static TimerHandle_t h_sensor_timer;
 
 /* temperature and humidity sensor */
 static void update_temperature_sensor_data(TimerHandle_t handle)
@@ -18,13 +17,9 @@ static void update_temperature_sensor_data(TimerHandle_t handle)
     esp_rmaker_param_update_and_report(
                 esp_rmaker_device_get_param_by_type(temp_sensor_device, ESP_RMAKER_PARAM_TEMPERATURE),
                 esp_rmaker_float(get_average_temperature()));
-}
-
-static void update_humidity_sensor_data(TimerHandle_t handle)
-{
     ESP_LOGI(TAG, "Updating Humidity: %.1f%%\n", get_average_humidity());
     esp_rmaker_param_update_and_report(
-                esp_rmaker_device_get_param_by_type(humidity_sensor_device, ESP_RMAKER_PARAM_TEMPERATURE),
+                esp_rmaker_device_get_param_by_name(temp_sensor_device, "Humidity"),    // 'Humidity' is the name of the parameter
                 esp_rmaker_float(get_average_humidity()));
 }
 
@@ -39,14 +34,4 @@ esp_err_t temperature_sensor_init(void)
     return ESP_FAIL;
 }
 
-esp_err_t humidity_sensor_init(void)
-{
-    h_sensor_timer = xTimerCreate("update_humidity_sensor_data", (REPORTING_PERIOD * 1000) / portTICK_PERIOD_MS,
-                            pdTRUE, NULL, update_humidity_sensor_data);
-    if (h_sensor_timer) {
-        xTimerStart(h_sensor_timer, 0);
-        return ESP_OK;
-    }
-    return ESP_FAIL;
-}
 /* temperature and humidity sensor - END */

--- a/main/app_driver.c
+++ b/main/app_driver.c
@@ -20,6 +20,7 @@
 #include "app_priv.h"
 
 #include "dht21.h"
+#include "csms_v2.h"
 
 /* This is the button that is used for toggling the power */
 #define BUTTON_GPIO          CONFIG_ESP32_BOARD_BUTTON_GPIO
@@ -131,5 +132,8 @@ void app_driver_init()
     xTaskCreate(set_average_temperature_humidity, "set_average_temperature_humidity", configMINIMAL_STACK_SIZE * 3, NULL, 5, NULL);
     /* Create a task to turn off the switch after a set interval */
     xTaskCreate(turnOffSwitchAfterSetInterval, "turnOffSwitchAfterSetInterval", configMINIMAL_STACK_SIZE * 3, NULL, 5, NULL);
-
+    /* Create a task to set the soil moisture data */
+    xTaskCreate(set_average_soil_moisture_data, "set_average_soil_moisture_data", 4096, NULL, 5, NULL);
+    /* Create a task to display the soil moisture data */
+    xTaskCreate(display_average_soil_moisture_data, "display_average_soil_moisture_data", 4096, NULL, 5, NULL);
 }

--- a/main/app_driver.c
+++ b/main/app_driver.c
@@ -136,4 +136,6 @@ void app_driver_init()
     xTaskCreate(set_average_soil_moisture_data, "set_average_soil_moisture_data", 4096, NULL, 5, NULL);
     /* Create a task to display the soil moisture data */
     xTaskCreate(display_average_soil_moisture_data, "display_average_soil_moisture_data", 4096, NULL, 5, NULL);
+    /* Create a task to update the temperature sensor data */
+    soil_moisture_sensor_init();
 }

--- a/main/app_driver.c
+++ b/main/app_driver.c
@@ -127,7 +127,6 @@ void app_driver_init()
     
     /* Init the temperature and humidity sensor */
     temperature_sensor_init();
-    humidity_sensor_init();
     /* Create a task to set the average temperature and humidity */
     xTaskCreate(set_average_temperature_humidity, "set_average_temperature_humidity", configMINIMAL_STACK_SIZE * 3, NULL, 5, NULL);
     /* Create a task to turn off the switch after a set interval */

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -221,7 +221,7 @@ void app_main()
     esp_rmaker_node_add_device(node, switch_device);
 
     /* Create a Temperature Sensor device and add the relevant parameters to it */
-    temp_sensor_device = esp_rmaker_temp_sensor_device_create("Temperature Sensor", NULL, get_average_temperature());
+    temp_sensor_device = esp_rmaker_temp_sensor_device_create("Temperature/Humidty", NULL, get_average_temperature());
     esp_rmaker_param_t *h_param = esp_rmaker_param_create("Humidity", ESP_RMAKER_PARAM_TEMPERATURE, 
         esp_rmaker_float(get_average_humidity()), PROP_FLAG_READ | PROP_FLAG_TIME_SERIES);
     esp_rmaker_device_add_param( temp_sensor_device, h_param);

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -35,7 +35,6 @@
 static const char *TAG = "app_main";
 esp_rmaker_device_t *switch_device;
 esp_rmaker_device_t *temp_sensor_device;
-esp_rmaker_device_t *humidity_sensor_device;
 
 /* Callback to handle commands received from the RainMaker cloud */
 static esp_err_t write_cb(const esp_rmaker_device_t *device, const esp_rmaker_param_t *param,
@@ -223,11 +222,10 @@ void app_main()
 
     /* Create a Temperature Sensor device and add the relevant parameters to it */
     temp_sensor_device = esp_rmaker_temp_sensor_device_create("Temperature Sensor", NULL, get_average_temperature());
+    esp_rmaker_param_t *h_param = esp_rmaker_param_create("Humidity", ESP_RMAKER_PARAM_TEMPERATURE, 
+        esp_rmaker_float(get_average_humidity()), PROP_FLAG_READ | PROP_FLAG_TIME_SERIES);
+    esp_rmaker_device_add_param( temp_sensor_device, h_param);
     esp_rmaker_node_add_device(node, temp_sensor_device);
-
-    /* Create a Humidity Sensor device and add the relevant parameters to it */
-    humidity_sensor_device = esp_rmaker_temp_sensor_device_create("Humidity Sensor", NULL, get_average_humidity());
-    esp_rmaker_node_add_device(node, humidity_sensor_device);
 
     /* Enable OTA */
     esp_rmaker_ota_enable_default();

--- a/main/app_priv.h
+++ b/main/app_priv.h
@@ -14,13 +14,10 @@
 #define DEFAULT_POWER  false
 extern esp_rmaker_device_t *switch_device;
 extern esp_rmaker_device_t *temp_sensor_device;
-extern esp_rmaker_device_t *humidity_sensor_device;
-
 
 void app_driver_init(void);
 int app_driver_set_state(bool state);
 bool app_driver_get_state(void);
 
 esp_err_t temperature_sensor_init(void);
-esp_err_t humidity_sensor_init(void);
 esp_err_t soil_moisture_sensor_init(void);

--- a/main/app_priv.h
+++ b/main/app_priv.h
@@ -23,3 +23,4 @@ bool app_driver_get_state(void);
 
 esp_err_t temperature_sensor_init(void);
 esp_err_t humidity_sensor_init(void);
+esp_err_t soil_moisture_sensor_init(void);

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,3 +1,5 @@
 dependencies:
   dht21:
     path: ../components/dht21
+  csms_v2:
+    path: ../components/csms_v2


### PR DESCRIPTION
- Adding a component to read soil moisture sensor data using a 16-channel multiplexer(CD74HC4067).
- Soil Moisture sensor init and read for esp-rainmaker.
- Removed Humidity sensor as a device and added humidity as a parameter to the existing temperature sensor to reduce clutter.
- Updated Temperature sensor device name.